### PR TITLE
Modificación a llamadas Repository.delete()

### DIFF
--- a/src/main/java/com/edutech/springboot/crud/edutech_crud/services/CursoServiceImpl.java
+++ b/src/main/java/com/edutech/springboot/crud/edutech_crud/services/CursoServiceImpl.java
@@ -39,7 +39,7 @@ public class CursoServiceImpl implements CursoService {
     public Optional<Curso> delete(Curso unCurso) {
         Optional<Curso> cursoOptional = repository.findById(unCurso.getId());
         cursoOptional.ifPresent(cursoDb -> {
-            repository.delete(unCurso);
+            repository.delete(cursoDb);
         });
         return cursoOptional;
     }

--- a/src/main/java/com/edutech/springboot/crud/edutech_crud/services/ProveedorServiceImpl.java
+++ b/src/main/java/com/edutech/springboot/crud/edutech_crud/services/ProveedorServiceImpl.java
@@ -21,7 +21,7 @@ public class ProveedorServiceImpl implements ProveedorService{
     public Optional<Proveedor> delete(Proveedor unProveedor) {
         Optional<Proveedor> proveedorOptional = repository.findById(unProveedor.getId());
         proveedorOptional.ifPresent(proveedorDb->{
-            repository.delete(unProveedor);
+            repository.delete(proveedorDb);
         });
         return proveedorOptional;
     }

--- a/src/main/java/com/edutech/springboot/crud/edutech_crud/services/UsuarioServiceImpl.java
+++ b/src/main/java/com/edutech/springboot/crud/edutech_crud/services/UsuarioServiceImpl.java
@@ -44,7 +44,7 @@ public class UsuarioServiceImpl implements UsuarioService{
     public Optional<Usuario> delete(Usuario unUsuario) {
         Optional<Usuario> userOpcional = repository.findById(unUsuario.getId());
         userOpcional.ifPresent(usuarioDb->{
-            repository.delete(unUsuario);
+            repository.delete(usuarioDb);
         });
         return userOpcional;
     }

--- a/src/main/java/com/edutech/springboot/crud/edutech_crud/services/UsuarioServiceImpl.java
+++ b/src/main/java/com/edutech/springboot/crud/edutech_crud/services/UsuarioServiceImpl.java
@@ -49,7 +49,4 @@ public class UsuarioServiceImpl implements UsuarioService{
         return userOpcional;
     }
 
-
- 
-
 }


### PR DESCRIPTION
Se reemplazan las llamadas a `repository.delete(unObjeto)` por `repository.delete(objetoDb)` en cada clase `ServiceImpl` para utilizar el objeto que se obtiene desde el repositorio. Esto mejora la seguridad en casos extremos, ya que se utiliza una instancia de objeto **gestionada por el contexto de persistencia.**

_Ejemplo (antes):_
```
cursoOptional.ifPresent(cursoDb -> {
    repository.delete(unCurso);  // objeto externo
});
```
_Ejemplo (después):_
```
cursoOptional.ifPresent(cursoDb -> {
    repository.delete(cursoDb);  // objeto gestionado
});
```