### PR TITLE
Proveedor tests

### DIFF
--- a/src/test/java/com/edutech/springboot/crud/edutech_crud/restcontrollers/ProveedorRestControllersTest.java
+++ b/src/test/java/com/edutech/springboot/crud/edutech_crud/restcontrollers/ProveedorRestControllersTest.java
@@ -46,7 +46,7 @@ public class ProveedorRestControllersTest {
         Proveedor unProveedor = new Proveedor(1L, "76.124.876-5", "Muebles para oficina Valledor", "mueblesvalledor@gmail.com", "Venta de muebles");
         try {
             when(proveedorServiceImpl.findById(1L)).thenReturn(Optional.of(unProveedor));
-            mockMvc.perform(get("/api/proveedor/1").contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk());
+            mockMvc.perform(get("/api/proveedores/1").contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk());
         } catch (Exception ex) {
             fail("El testing lanzó un error " + ex.getMessage());
         }
@@ -55,7 +55,7 @@ public class ProveedorRestControllersTest {
     @Test
     public void proveedorNoExisteTest() throws Exception {
         when(proveedorServiceImpl.findById(10L)).thenReturn(Optional.empty());
-        mockMvc.perform(get("/api/proveedor/10").contentType(MediaType.APPLICATION_JSON)).andExpect(status().isNotFound());
+        mockMvc.perform(get("/api/proveedores/10").contentType(MediaType.APPLICATION_JSON)).andExpect(status().isNotFound());
     }
 
     @Test
@@ -63,7 +63,7 @@ public class ProveedorRestControllersTest {
         Proveedor unProveedor = new Proveedor(4L, "76.124.876-5", "Muebles para oficina Valledor", "mueblesvalledor@gmail.com", "Venta de muebles");
         Proveedor otroProveedor = new Proveedor(null, "87.324.765-6", "Artículos de oficina López", "articuloslopez@gmail.com", "Venta de artículos de oficina");
         when(proveedorServiceImpl.save(any(Proveedor.class))).thenReturn(otroProveedor);
-        mockMvc.perform(post("/api/proveedor").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(unProveedor))).andExpect(status().isCreated());
-
+        mockMvc.perform(post("/api/proveedores").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(unProveedor))).andExpect(status().isCreated());
     }
+
 }

--- a/src/test/java/com/edutech/springboot/crud/edutech_crud/restcontrollers/ProveedorRestControllersTest.java
+++ b/src/test/java/com/edutech/springboot/crud/edutech_crud/restcontrollers/ProveedorRestControllersTest.java
@@ -3,18 +3,23 @@ package com.edutech.springboot.crud.edutech_crud.restcontrollers;
 import java.util.List;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.edutech.springboot.crud.edutech_crud.entities.Proveedor;
 import com.edutech.springboot.crud.edutech_crud.services.ProveedorServiceImpl;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -45,5 +50,20 @@ public class ProveedorRestControllersTest {
         } catch (Exception ex) {
             fail("El testing lanzó un error " + ex.getMessage());
         }
+    }
+
+    @Test
+    public void proveedorNoExisteTest() throws Exception {
+        when(proveedorServiceImpl.findById(10L)).thenReturn(Optional.empty());
+        mockMvc.perform(get("/api/proveedor/10").contentType(MediaType.APPLICATION_JSON)).andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void crearProveedorTest() throws Exception {
+        Proveedor unProveedor = new Proveedor(4L, "76.124.876-5", "Muebles para oficina Valledor", "mueblesvalledor@gmail.com", "Venta de muebles");
+        Proveedor otroProveedor = new Proveedor(null, "87.324.765-6", "Artículos de oficina López", "articuloslopez@gmail.com", "Venta de artículos de oficina");
+        when(proveedorServiceImpl.save(any(Proveedor.class))).thenReturn(otroProveedor);
+        mockMvc.perform(post("/api/proveedor").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(unProveedor))).andExpect(status().isCreated());
+
     }
 }

--- a/src/test/java/com/edutech/springboot/crud/edutech_crud/restcontrollers/ProveedorRestControllersTest.java
+++ b/src/test/java/com/edutech/springboot/crud/edutech_crud/restcontrollers/ProveedorRestControllersTest.java
@@ -1,0 +1,49 @@
+package com.edutech.springboot.crud.edutech_crud.restcontrollers;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.edutech.springboot.crud.edutech_crud.entities.Proveedor;
+import com.edutech.springboot.crud.edutech_crud.services.ProveedorServiceImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ProveedorRestControllersTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private  ProveedorServiceImpl proveedorServiceImpl;
+
+    private List<Proveedor> proveedorList;
+
+    @Test
+    public void verProveedoresTest() throws Exception {
+        when(proveedorServiceImpl.findByAll()).thenReturn(proveedorList);
+    }
+
+    @Test
+    public void verunProveedorTest() {
+        Proveedor unProveedor = new Proveedor(1L, "76.124.876-5", "Muebles para oficina Valledor", "mueblesvalledor@gmail.com", "Venta de muebles");
+        try {
+            when(proveedorServiceImpl.findById(1L)).thenReturn(Optional.of(unProveedor));
+            mockMvc.perform(get("/api/proveedor/1").contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk());
+        } catch (Exception ex) {
+            fail("El testing lanzó un error " + ex.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/edutech/springboot/crud/edutech_crud/services/ProveedorServiceImplTest.java
+++ b/src/test/java/com/edutech/springboot/crud/edutech_crud/services/ProveedorServiceImplTest.java
@@ -25,7 +25,7 @@ public class ProveedorServiceImplTest {
     @Mock
     private ProveedorRepository repository;
 
-    List<Proveedor> list = new ArrayList<Proveedor>();
+    List<Proveedor> list = new ArrayList<>();
 
     @BeforeEach
     public void init() {

--- a/src/test/java/com/edutech/springboot/crud/edutech_crud/services/ProveedorServiceImplTest.java
+++ b/src/test/java/com/edutech/springboot/crud/edutech_crud/services/ProveedorServiceImplTest.java
@@ -1,0 +1,58 @@
+package com.edutech.springboot.crud.edutech_crud.services;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.MockitoAnnotations;
+
+import com.edutech.springboot.crud.edutech_crud.entities.Proveedor;
+import com.edutech.springboot.crud.edutech_crud.repository.ProveedorRepository;
+
+public class ProveedorServiceImplTest {
+
+    @InjectMocks
+    private ProveedorServiceImpl service;
+
+    @Mock
+    private ProveedorRepository repository;
+
+    List<Proveedor> list = new ArrayList<Proveedor>();
+
+    @BeforeEach
+    public void init() {
+        MockitoAnnotations.openMocks(this);
+
+        this.chargeProveedor();
+    }
+
+    @Test
+    public void findByAllTest() {
+
+        when(repository.findAll()).thenReturn(list);
+
+        List<Proveedor> response = service.findByAll();
+
+        assertEquals(3, response.size());
+
+        verify(repository, times(1)).findAll();
+    }
+
+    public void chargeProveedor() {
+        Proveedor prov1 = new Proveedor(Long.valueOf(1), "76.124.876-5", "Muebles para oficina Valledor", "mueblesvalledor@gmail.com", "Venta de muebles");
+        Proveedor prov2 = new Proveedor(Long.valueOf(2), "87.324.765-6", "Artículos de oficina López", "articuloslopez@gmail.com", "Venta de artículos de oficina");
+        Proveedor prov3 = new Proveedor(Long.valueOf(3), "84.876.987-4", "Impresoras de Juanito", "juanitoimpresoras@gmail.com", "Venta de impresoras");
+
+        list.add(prov1);
+        list.add(prov2);
+        list.add(prov3);
+    }
+}


### PR DESCRIPTION
### Agrega pruebas unitarias y de integración para la clase Proveedor

Se agregan las siguientes pruebas:

**Pruebas Unitarias para ProveedorServiceImpl**  
- `findByAllTest` – Verifica que se retorne la lista completa de proveedores

**Pruebas de Integración para ProveedorRestController:**  
- `verProveedoresTest` – Verifica que se retornen todos los proveedores
- `verunProveedorTest` – Verifica la respuesta al consultar un proveedor por ID
- `proveedorNoExisteTest` – Verifica la respuesta cuando se consulta un proveedor inexistente
- `crearProveedorTest` – Verifica el comportamiento al crear un proveedor

